### PR TITLE
feat: add kortex API support for aarch64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## Upcoming changes
+
+- feat: add kortex API support for aarch64 (#1)

--- a/kortex_api/CMakeLists.txt
+++ b/kortex_api/CMakeLists.txt
@@ -1,37 +1,22 @@
 cmake_minimum_required(VERSION 3.14)
-include(FetchContent)
-#include(ExternalProject)
-FetchContent_Declare(
-  kinova_binary_api
-  URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.5.0/linux_x86-64_x86_gcc.zip
-  URL_HASH MD5=64bd86e7ab8bda90ef1fc7d6a356e080
-)
-
-FetchContent_MakeAvailable(kinova_binary_api)
-
 project(kortex_api)
 
-#Future:
-# convert API_URL components from CMAKE_SYSTEM variables.
-# The kinova artifactory server artifacts have slightly different expectations and they need some transformations
-# Could build something like: (URL_OS)_(URL_PROCESSOR)_(?)_(URL_COMPILER).zip
-# string(REPLACE "_" "-" URL_PROCESSOR ${CMAKE_SYSTEM_PROCESSOR}) # x86_64 -> x86-64
-# string(TOLOWER ${CMAKE_SYSTEM_NAME} URL_OS) # Linux -> linux
-
-#Current: only support Linux x86_64
+#Current: only support Linux x86_64 and aarch64
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-  set(API_URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.5.0/linux_x86-64_x86_gcc.zip)
+  set(API_URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.6.0/linux_x86-64_x86_gcc.zip)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  set(API_URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.6.0/linux_armv7_artik710_gcc.zip)
 else()
   set(API_URL "")
-  message(FATAL_ERROR "Unsupported System: currently support is for Linux x68_64. Detected ${CMAKE_SYSTEM_NAME} and ${CMAKE_SYSTEM_PROCESSOR}")
+  message(FATAL_ERROR "Unsupported System: currently support is for Linux x68_64/aarch64. Detected ${CMAKE_SYSTEM_NAME} and ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
-#ExternalProject_Add(kinova_binary_api
-#  URL ${API_URL}
-#  CONFIGURE_COMMAND ""
-#  BUILD_COMMAND ""
-#  INSTALL_COMMAND ""
-#)
+include(FetchContent)
+FetchContent_Declare(
+  kinova_binary_api
+  URL ${API_URL}
+)
+FetchContent_MakeAvailable(kinova_binary_api)
 
 find_package(ament_cmake REQUIRED)
 

--- a/kortex_driver/CMakeLists.txt
+++ b/kortex_driver/CMakeLists.txt
@@ -1,12 +1,4 @@
 cmake_minimum_required(VERSION 3.14)
-include(FetchContent)
-FetchContent_Declare(
-  kinova_binary_api
-  URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.5.0/linux_x86-64_x86_gcc.zip
-  URL_HASH MD5=64bd86e7ab8bda90ef1fc7d6a356e080
-)
-FetchContent_MakeAvailable(kinova_binary_api)
-
 project(kortex_driver)
 
 # Default to C++14
@@ -18,6 +10,23 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra)
 endif()
 
+#Current: only support Linux x86_64 and aarch64
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set(API_URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.6.0/linux_x86-64_x86_gcc.zip)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  set(API_URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.6.0/linux_armv7_artik710_gcc.zip)
+else()
+  set(API_URL "")
+  message(FATAL_ERROR "Unsupported System: currently support is for Linux x68_64/aarch64. Detected ${CMAKE_SYSTEM_NAME} and ${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
+include(FetchContent)
+FetchContent_Declare(
+  kinova_binary_api
+  URL ${API_URL}
+)
+FetchContent_MakeAvailable(kinova_binary_api)
+
 # this is needed by the kortex_api to tell it we are compiling for linux
 add_definitions(-D_OS_UNIX=1)
 
@@ -27,16 +36,6 @@ find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(kortex_api REQUIRED)
-
-#Current: only support Linux x86_64
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-  set(API_URL https://artifactory.kinovaapps.com:443/artifactory/generic-public/kortex/API/2.5.0/linux_x86-64_x86_gcc.zip)
-else()
-  # TODO(future) to support ARM or other builds logic could go here to fetch the precompiled libKortexApiCpp.a
-  # see notes in kortex_api CMakeList.txt
-  message(WARNING "Detected ${CMAKE_SYSTEM_NAME} and ${CMAKE_SYSTEM_PROCESSOR}")
-  message(FATAL_ERROR "Unsupported System: currently support is for Linux x68_64.")
-endif()
 
 # CMake does not allow IMPORTED libraries to be installed
 # The package kortex_api will download and setup the include directories


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Explain what the PR does and why it is useful
3. Add any supporting resources (screenshots, test results, etc)
4. Help the reviewer by suggesting the method and estimated time to review
5. If applicable, make a checklist of tasks that should be completed before merging
6. If applicable, mention related issues (blocked by / blocks)
7. Post creation actions: tag reviewers and optionally link the PR to its related issues under the Development section
-->

## Description

<!-- Required: explain what the PR does and why it is useful -->
This PR changes the CMakeLists of the `kortex_api` and `kortex_driver` packages to support aarch64 on Linux too, in order to be integrated with the AICA stack. Tested on Raspberry Pi 5 and by @LouisBrunner 

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->