### PR TITLE
feat(description): add urdf example for gen3 7dof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - feat: add kortex API support for aarch64 (#1)
 - fix(build): update kortex api links (#2)
+- feat(description): add urdf example for gen3 7dof (#3)

--- a/kortex_description/CMakeLists.txt
+++ b/kortex_description/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 
 install(
-  DIRECTORY arms grippers launch multiple_robots robots rviz config
+  DIRECTORY arms grippers launch multiple_robots robots rviz config urdf_examples
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/kortex_description/arms/gen3/6dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/6dof/urdf/gen3_macro.xacro
@@ -127,7 +127,7 @@
     <xacro:unless value="${use_external_cable}">
       <joint
         name="${prefix}joint_1"
-        type="continuous">
+        type="revolute">
         <origin
           xyz="0 0 0.15643"
           rpy="-3.1416 0.0 0.0" />
@@ -242,7 +242,7 @@
       </joint>
     </xacro:if>
     <xacro:unless value="${use_external_cable}">
-      <joint name="${prefix}joint_4" type="continuous">
+      <joint name="${prefix}joint_4" type="revolute">
         <origin xyz="0 0.20843 -0.006375" rpy="1.5708 0.0 0.0" />
         <parent link="${prefix}forearm_link" />
         <child link="${prefix}spherical_wrist_1_link" />
@@ -337,7 +337,7 @@
       </joint>
     </xacro:if>
     <xacro:unless value="${use_external_cable}">
-      <joint name="${prefix}joint_6" type="continuous">
+      <joint name="${prefix}joint_6" type="revolute">
         <origin xyz="0 0.10593 -0.00017505" rpy="1.5708 0.0 0.0" />
         <parent link="${prefix}spherical_wrist_2_link" />
         <child link="${prefix}bracelet_link" />

--- a/kortex_description/arms/gen3/6dof/urdf/kortex.ros2_control.xacro
+++ b/kortex_description/arms/gen3/6dof/urdf/kortex.ros2_control.xacro
@@ -61,8 +61,8 @@
       </hardware>
       <joint name="${prefix}joint_1">
         <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
+          <param name="min">${-2*pi}</param>
+          <param name="max">${2*pi}</param>
         </command_interface>
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_1']}</param>
@@ -94,8 +94,8 @@
       </joint>
       <joint name="${prefix}joint_4">
         <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
+          <param name="min">${-2*pi}</param>
+          <param name="max">${2*pi}</param>
         </command_interface>
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_4']}</param>
@@ -116,8 +116,8 @@
       </joint>
       <joint name="${prefix}joint_6">
         <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
+          <param name="min">${-2*pi}</param>
+          <param name="max">${2*pi}</param>
         </command_interface>
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_6']}</param>

--- a/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
@@ -128,7 +128,7 @@
     <xacro:unless value="${use_external_cable}">
       <joint
         name="${prefix}joint_1"
-        type="continuous">
+        type="revolute">
         <origin xyz="0 0 0.15643" rpy="3.1416 2.7629E-18 -4.9305E-36" />
         <parent
           link="${prefix}base_link" />
@@ -218,7 +218,7 @@
     <xacro:unless value="${use_external_cable}">
       <joint
         name="${prefix}joint_3"
-        type="continuous">
+        type="revolute">
         <origin xyz="0 -0.21038 -0.006375" rpy="-1.5708 1.2326E-32 -2.9122E-16" />
         <parent
           link="${prefix}half_arm_1_link" />
@@ -308,7 +308,7 @@
     <xacro:unless value="${use_external_cable}">
       <joint
         name="${prefix}joint_5"
-        type="continuous">
+        type="revolute">
         <origin xyz="0 -0.20843 -0.006375" rpy="-1.5708 2.2204E-16 -6.373E-17" />
         <parent
           link="${prefix}forearm_link" />
@@ -424,7 +424,7 @@
     <xacro:unless value="${use_external_cable}">
       <joint
         name="${prefix}joint_7"
-        type="continuous">
+        type="revolute">
         <origin xyz="0 -0.10593 -0.00017505" rpy="-1.5708 -5.5511E-17 9.6396E-17" />
         <parent
           link="${prefix}spherical_wrist_2_link" />

--- a/kortex_description/arms/gen3/7dof/urdf/kortex.ros2_control.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/kortex.ros2_control.xacro
@@ -61,8 +61,8 @@
       </hardware>
       <joint name="${prefix}joint_1">
         <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
+          <param name="min">${-2*pi}</param>
+          <param name="max">${2*pi}</param>
         </command_interface>
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_1']}</param>
@@ -83,8 +83,8 @@
       </joint>
       <joint name="${prefix}joint_3">
         <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
+          <param name="min">${-2*pi}</param>
+          <param name="max">${2*pi}</param>
         </command_interface>
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_3']}</param>
@@ -105,8 +105,8 @@
       </joint>
       <joint name="${prefix}joint_5">
         <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
+          <param name="min">${-2*pi}</param>
+          <param name="max">${2*pi}</param>
         </command_interface>
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_5']}</param>
@@ -127,8 +127,8 @@
       </joint>
       <joint name="${prefix}joint_7">
         <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
+          <param name="min">${-2*pi}</param>
+          <param name="max">${2*pi}</param>
         </command_interface>
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_7']}</param>

--- a/kortex_description/robots/gen3_2f85.urdf
+++ b/kortex_description/robots/gen3_2f85.urdf
@@ -28,8 +28,8 @@
     </hardware>
     <joint name="gen3_joint_1">
       <command_interface name="position">
-        <param name="min">{-2*pi}</param>
-        <param name="max">{2*pi}</param>
+        <param name="min">${-2*pi}</param>
+        <param name="max">${2*pi}</param>
       </command_interface>
       <command_interface name="velocity">
         <param name="min">-3.15</param>
@@ -58,8 +58,8 @@
     </joint>
     <joint name="gen3_joint_3">
       <command_interface name="position">
-        <param name="min">{-2*pi}</param>
-        <param name="max">{2*pi}</param>
+        <param name="min">${-2*pi}</param>
+        <param name="max">${2*pi}</param>
       </command_interface>
       <command_interface name="velocity">
         <param name="min">-3.15</param>
@@ -88,8 +88,8 @@
     </joint>
     <joint name="gen3_joint_5">
       <command_interface name="position">
-        <param name="min">{-2*pi}</param>
-        <param name="max">{2*pi}</param>
+        <param name="min">${-2*pi}</param>
+        <param name="max">${2*pi}</param>
       </command_interface>
       <command_interface name="velocity">
         <param name="min">-3.2</param>
@@ -118,8 +118,8 @@
     </joint>
     <joint name="gen3_joint_7">
       <command_interface name="position">
-        <param name="min">{-2*pi}</param>
-        <param name="max">{2*pi}</param>
+        <param name="min">${-2*pi}</param>
+        <param name="max">${2*pi}</param>
       </command_interface>
       <command_interface name="velocity">
         <param name="min">-3.2</param>

--- a/kortex_description/urdf_examples/kinova_gen3.urdf
+++ b/kortex_description/urdf_examples/kinova_gen3.urdf
@@ -1,0 +1,343 @@
+<?xml version="1.0" ?>
+<robot name="kinova">
+  <!-- create link fixed to the "world" -->
+  <link name="world"/>
+  <ros2_control name="kinova_KortexMultiInterfaceHardware" type="system">
+    <hardware>
+      <plugin>kortex_driver/KortexMultiInterfaceHardware</plugin>
+      <param name="robot_ip">192.168.11.11</param>
+      <param name="username">admin</param>
+      <param name="password">admin</param>
+      <param name="port">10000</param>
+      <param name="port_realtime">10001</param>
+      <param name="session_inactivity_timeout_ms">60000</param>
+      <param name="connection_inactivity_timeout_ms">2000</param>
+      <param name="tf_prefix">""</param>
+      <param name="use_internal_bus_gripper_comm">False</param>
+      <param name="gripper_joint_name">finger_joint</param>
+      <param name="gripper_max_velocity">100.0</param>
+      <param name="gripper_max_force">100.0</param>
+    </hardware>
+    <joint name="kinova_joint_1">
+      <command_interface name="position">
+        <param name="min">-6.283185307179586</param>
+        <param name="max">6.283185307179586</param>
+      </command_interface>
+      <state_interface name="position">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>
+    <joint name="kinova_joint_2">
+      <command_interface name="position">
+        <param name="min">-2.41</param>
+        <param name="max">2.41</param>
+      </command_interface>
+      <state_interface name="position">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>
+    <joint name="kinova_joint_3">
+      <command_interface name="position">
+        <param name="min">-6.283185307179586</param>
+        <param name="max">6.283185307179586</param>
+      </command_interface>
+      <state_interface name="position">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>
+    <joint name="kinova_joint_4">
+      <command_interface name="position">
+        <param name="min">-2.66</param>
+        <param name="max">2.66</param>
+      </command_interface>
+      <state_interface name="position">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>
+    <joint name="kinova_joint_5">
+      <command_interface name="position">
+        <param name="min">-6.283185307179586</param>
+        <param name="max">6.283185307179586</param>
+      </command_interface>
+      <state_interface name="position">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>
+    <joint name="kinova_joint_6">
+      <command_interface name="position">
+        <param name="min">-2.23</param>
+        <param name="max">2.23</param>
+      </command_interface>
+      <state_interface name="position">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>
+    <joint name="kinova_joint_7">
+      <command_interface name="position">
+        <param name="min">-6.283185307179586</param>
+        <param name="max">6.283185307179586</param>
+      </command_interface>
+      <state_interface name="position">
+        <param name="initial_value">0.0</param>
+      </state_interface>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>
+  </ros2_control>
+  <joint name="kinova_base_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="world"/>
+    <child link="kinova_base_link"/>
+  </joint>
+  <link name="kinova_base_link">
+    <inertial>
+      <origin rpy="0 0 0" xyz="-0.000648 -0.000166 0.084487"/>
+      <mass value="1.697"/>
+      <inertia ixx="0.004622" ixy="9E-06" ixz="6E-05" iyy="0.004495" iyz="9E-06" izz="0.002079"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/base_link.dae"/>
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/base_link.dae"/>
+      </geometry>
+    </collision>
+  </link>
+  <link name="kinova_shoulder_link">
+    <inertial>
+      <origin rpy="0 0 0" xyz="-2.3E-05 -0.010364 -0.07336"/>
+      <mass value="1.3773"/>
+      <inertia ixx="0.00457" ixy="1E-06" ixz="2E-06" iyy="0.004831" iyz="0.000448" izz="0.001409"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/shoulder_link.dae"/>
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/shoulder_link.dae"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="kinova_joint_1" type="revolute">
+    <origin rpy="3.1416 2.7629E-18 -4.9305E-36" xyz="0 0 0.15643"/>
+    <parent link="kinova_base_link"/>
+    <child link="kinova_shoulder_link"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="39" velocity="1.3963"/>
+  </joint>
+  <link name="kinova_half_arm_1_link">
+    <inertial>
+      <origin rpy="0 0 0" xyz="-4.4E-05 -0.09958 -0.013278"/>
+      <mass value="1.1636"/>
+      <inertia ixx="0.011088" ixy="5E-06" ixz="0" iyy="0.001072" iyz="-0.000691" izz="0.011255"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/half_arm_1_link.dae"/>
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/half_arm_1_link.dae"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="kinova_joint_2" type="revolute">
+    <origin rpy="1.5708 2.1343E-17 -1.1102E-16" xyz="0 0.005375 -0.12838"/>
+    <parent link="kinova_shoulder_link"/>
+    <child link="kinova_half_arm_1_link"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="39" lower="-2.41" upper="2.41" velocity="1.3963"/>
+  </joint>
+  <link name="kinova_half_arm_2_link">
+    <inertial>
+      <origin rpy="0 0 0" xyz="-4.4E-05 -0.006641 -0.117892"/>
+      <mass value="1.1636"/>
+      <inertia ixx="0.010932" ixy="0" ixz="-7E-06" iyy="0.011127" iyz="0.000606" izz="0.001043"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/half_arm_2_link.dae"/>
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/half_arm_2_link.dae"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="kinova_joint_3" type="revolute">
+    <origin rpy="-1.5708 1.2326E-32 -2.9122E-16" xyz="0 -0.21038 -0.006375"/>
+    <parent link="kinova_half_arm_1_link"/>
+    <child link="kinova_half_arm_2_link"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="39" velocity="1.3963"/>
+  </joint>
+  <link name="kinova_forearm_link">
+    <inertial>
+      <origin rpy="0 0 0" xyz="-1.8E-05 -0.075478 -0.015006"/>
+      <mass value="0.9302"/>
+      <inertia ixx="0.008147" ixy="-1E-06" ixz="0" iyy="0.000631" iyz="-0.0005" izz="0.008316"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/forearm_link.dae"/>
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/forearm_link.dae"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="kinova_joint_4" type="revolute">
+    <origin rpy="1.5708 -6.6954E-17 -1.6653E-16" xyz="0 0.006375 -0.21038"/>
+    <parent link="kinova_half_arm_2_link"/>
+    <child link="kinova_forearm_link"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="39" lower="-2.66" upper="2.66" velocity="1.3963"/>
+  </joint>
+  <link name="kinova_spherical_wrist_1_link">
+    <inertial>
+      <origin rpy="0 0 0" xyz="1E-06 -0.009432 -0.063883"/>
+      <mass value="0.6781"/>
+      <inertia ixx="0.001596" ixy="0" ixz="0" iyy="0.001607" iyz="0.000256" izz="0.000399"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/spherical_wrist_1_link.dae"/>
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/spherical_wrist_1_link.dae"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="kinova_joint_5" type="revolute">
+    <origin rpy="-1.5708 2.2204E-16 -6.373E-17" xyz="0 -0.20843 -0.006375"/>
+    <parent link="kinova_forearm_link"/>
+    <child link="kinova_spherical_wrist_1_link"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="9" velocity="1.2218"/>
+  </joint>
+  <link name="kinova_spherical_wrist_2_link">
+    <inertial>
+      <origin rpy="0 0 0" xyz="1E-06 -0.045483 -0.00965"/>
+      <mass value="0.6781"/>
+      <inertia ixx="0.001641" ixy="0" ixz="0" iyy="0.00041" iyz="-0.000278" izz="0.001641"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/spherical_wrist_2_link.dae"/>
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/spherical_wrist_2_link.dae"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="kinova_joint_6" type="revolute">
+    <origin rpy="1.5708 9.2076E-28 -8.2157E-15" xyz="0 0.00017505 -0.10593"/>
+    <parent link="kinova_spherical_wrist_1_link"/>
+    <child link="kinova_spherical_wrist_2_link"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="9" lower="-2.23" upper="2.23" velocity="1.2218"/>
+  </joint>
+  <link name="kinova_bracelet_link">
+    <inertial>
+      <origin rpy="0 0 0" xyz="-9.3E-05 0.000132 -0.022905"/>
+      <mass value="0.364"/>
+      <inertia ixx="0.000214" ixy="0" ixz="1E-06" iyy="0.000223" iyz="-2E-06" izz="0.00024"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/bracelet_no_vision_link.dae"/>
+      </geometry>
+      <material name="">
+        <color rgba="0.75294 0.75294 0.75294 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="file:///ws/install/kortex_description/share/kortex_description/arms/gen3/7dof/meshes/bracelet_no_vision_link.dae"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="kinova_joint_7" type="revolute">
+    <origin rpy="-1.5708 -5.5511E-17 9.6396E-17" xyz="0 -0.10593 -0.00017505"/>
+    <parent link="kinova_spherical_wrist_2_link"/>
+    <child link="kinova_bracelet_link"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="9" velocity="1.2218"/>
+  </joint>
+  <link name="kinova_end_effector_link"/>
+  <joint name="kinova_end_effector" type="fixed">
+    <origin rpy="3.14159265358979 1.09937075168372E-32 0" xyz="0 0 -0.0615250000000001"/>
+    <parent link="kinova_bracelet_link"/>
+    <child link="kinova_end_effector_link"/>
+    <axis xyz="0 0 0"/>
+  </joint>
+  <link name="kinova_tool_frame"/>
+  <joint name="kinova_tool_frame_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="kinova_end_effector_link"/>
+    <child link="kinova_tool_frame"/>
+    <axis xyz="0 0 0"/>
+  </joint>
+</robot>

--- a/kortex_description/urdf_examples/metadata.yaml
+++ b/kortex_description/urdf_examples/metadata.yaml
@@ -1,0 +1,3 @@
+kinova_gen3.urdf:
+  name: "Kinova Gen3 (default configuration, no gripper)"
+  description: "Kinova Gen3 7 DOF in default configuration with IP 192.168.11.11"


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Explain what the PR does and why it is useful
3. Add any supporting resources (screenshots, test results, etc)
4. Help the reviewer by suggesting the method and estimated time to review
5. If applicable, make a checklist of tasks that should be completed before merging
6. If applicable, mention related issues (blocked by / blocks)
7. Post creation actions: tag reviewers and optionally link the PR to its related issues under the Development section
-->

## Description

<!-- Required: explain what the PR does and why it is useful -->
This PR does two things:
1. It fixes some of the existing URDF macros because
  - we currently don't support "continuous" joints (hence the change to "revolute" joints)
  - if you want to use a variable like `pi` you need the dollar sign to write `${pi}` (no idea why that has not been fixed yet in the parent repo)
2. It adds the AICA style "urdf_examples" folder with a statically generated URDF and a metadata file. This is necessary to retrieve the URDF on the frontend.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->