### PR TITLE
fix: removes gripper from the launch default behaviour

### DIFF
--- a/kortex_bringup/launch/gen3.launch.py
+++ b/kortex_bringup/launch/gen3.launch.py
@@ -72,9 +72,9 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "gripper",
-            default_value="robotiq_2f_85",
+            default_value="",
             description="Name of the gripper attached to the arm",
-            choices=["robotiq_2f_85", "gen3_lite_2f"],
+            choices=["robotiq_2f_85", "gen3_lite_2f", ""],
         )
     )
     declared_arguments.append(
@@ -108,7 +108,6 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument("launch_rviz", default_value="true", description="Launch RViz?")
     )
-
     # Initialize Arguments
     robot_type = LaunchConfiguration("robot_type")
     robot_ip = LaunchConfiguration("robot_ip")

--- a/kortex_description/arms/gen3/7dof/urdf/kortex.ros2_control.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/kortex.ros2_control.xacro
@@ -57,12 +57,17 @@
           <param name="gripper_joint_name">${gripper_joint_name}</param>
           <param name="gripper_max_velocity">${gripper_max_velocity}</param>
           <param name="gripper_max_force">${gripper_max_force}</param>
+          <param name="effort_mode">3</param>
         </xacro:unless>
       </hardware>
       <joint name="${prefix}joint_1">
         <command_interface name="position">
           <param name="min">${-2*pi}</param>
           <param name="max">${2*pi}</param>
+        </command_interface>
+        <command_interface name="effort">
+          <param name="min">-56</param>
+          <param name="max">56</param>
         </command_interface>
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_1']}</param>
@@ -75,6 +80,10 @@
           <param name="min">-2.41</param>
           <param name="max">2.41</param>
         </command_interface>
+        <command_interface name="effort">
+          <param name="min">-56</param>
+          <param name="max">56</param>
+        </command_interface>
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_2']}</param>
         </state_interface>
@@ -85,6 +94,10 @@
         <command_interface name="position">
           <param name="min">${-2*pi}</param>
           <param name="max">${2*pi}</param>
+        </command_interface>
+        <command_interface name="effort">
+          <param name="min">-56</param>
+          <param name="max">56</param>
         </command_interface>
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_3']}</param>
@@ -97,6 +110,10 @@
           <param name="min">-2.66</param>
           <param name="max">2.66</param>
         </command_interface>
+        <command_interface name="effort">
+          <param name="min">-56</param>
+          <param name="max">56</param>
+        </command_interface>
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_4']}</param>
         </state_interface>
@@ -107,6 +124,10 @@
         <command_interface name="position">
           <param name="min">${-2*pi}</param>
           <param name="max">${2*pi}</param>
+        </command_interface>
+        <command_interface name="effort">
+          <param name="min">-29</param>
+          <param name="max">29</param>
         </command_interface>
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_5']}</param>
@@ -119,6 +140,10 @@
           <param name="min">-2.23</param>
           <param name="max">2.23</param>
         </command_interface>
+        <command_interface name="effort">
+          <param name="min">-29</param>
+          <param name="max">29</param>
+        </command_interface>
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_6']}</param>
         </state_interface>
@@ -129,6 +154,10 @@
         <command_interface name="position">
           <param name="min">${-2*pi}</param>
           <param name="max">${2*pi}</param>
+        </command_interface>
+        <command_interface name="effort">
+          <param name="min">-29</param>
+          <param name="max">29</param>
         </command_interface>
         <state_interface name="position">
           <param name="initial_value">${initial_positions['joint_7']}</param>

--- a/kortex_description/robots/gen3.xacro
+++ b/kortex_description/robots/gen3.xacro
@@ -13,7 +13,7 @@
     <xacro:arg name="port_realtime" default="10001" />
     <xacro:arg name="session_inactivity_timeout_ms" default="60000" />
     <xacro:arg name="connection_inactivity_timeout_ms" default="2000" />
-    <xacro:arg name="gripper" default="robotiq_2f_85" />
+    <xacro:arg name="gripper" default="" />
     <xacro:arg name="gripper_joint_name" default="finger_joint" />
     <xacro:arg name="gripper_max_velocity" default="100.0" />
     <xacro:arg name="gripper_max_force" default="100.0" />


### PR DESCRIPTION
Description
This PR removes the Robotiq 2F85 gripper from the launch default behavior, as we do not currently use it, which creates many warnings on the terminal. 

Additional comment
This is to sync among ourselves.

Review guidelines
Estimated Time of Review: 5 minutes

Checklist before merging:
- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes